### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ command:
 
 `reactify` transform activates for files with either `.js` or `.jsx` extensions.
 
+Some modules you might want to require won't work because of the way browserify applies transforms. In this case, use a -g rather than a -t to employ reactify.
+
+    % browserify -g reactify main.js
+
 If you want to reactify modules with other extensions, pass an `-x /
 --extension` option:
 


### PR DESCRIPTION
Add mention of -g instead of -t when the reactify isn't being applied to a file.

I don't really understand the difference, or why and when -g is required, so a better explanation is in order, but this is a lot better than nothing.
